### PR TITLE
Updated styling to use css instead of hard coded styles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509.4</version>
+    <version>1.596.2</version>
   </parent>
   
   <dependencies>

--- a/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/index.jelly
@@ -1,8 +1,8 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
     <l:layout>
         <l:main-panel>
-            <p align="right"><a href="configure">Configure</a><st:nbsp/><st:nbsp/><st:nbsp/><a href="delete">Delete</a></p><br /><br />
             <st:include page="main.jelly"/>
+            <p align="right"><a href="configure">Configure</a><st:nbsp/><st:nbsp/><st:nbsp/><a href="delete">Delete</a></p>
         </l:main-panel>
     </l:layout>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/main.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/main.jelly
@@ -3,31 +3,31 @@
 <link href="${rootURL}/plugin/environment-dashboard/css/bootstrap.min.css" type="text/css" rel="stylesheet"/>
 <link href="${rootURL}/plugin/environment-dashboard/css/bootstrap-theme.min.css" type="text/css" rel="stylesheet"/>
 <link href="${rootURL}/plugin/environment-dashboard/css/blink.css" type="text/css" rel="stylesheet"/>
+<link href="${rootURL}/plugin/environment-dashboard/css/main.css" type="text/css" rel="stylesheet"/>
 <div class="overlay" style="display:none; background-color: rgba(0, 0, 0, 0.4); position:absolute; top: 0; left:0; bottom:0; right:0;" onclick="hideAll()"></div>
 <div class="popup" id="popup" style="position: absolute; width: 300px; height:150; display:none; background-color: white; text-align: center; top:50%; left:50%; margin-left: -150px; margin-top: -75;"></div>
 <script src="//code.jquery.com/jquery-1.10.2.js"></script>
-<div id="startDashboard">
-    <table id="envDashboard" class="table table-bordered table-striped table-condensed">
-        <tbody>
+<div id="startDashboard" class="tableDiv">
+    
             <j:switch on="${it.anyJobsConfigured()}">
                 <j:case value="NONE">
-                    <tr>
+                    
                         <div class="jumbotron">
                             <h2>Hi, there!</h2>
                             <p>You possibly haven't set up any jobs to use the Dashboard. Or if you have, the job hasn't run atleast once. You can configure the jobs by using the 'Details for Environment Dashboard' checkbox.</p>
                         </div>
-                    </tr>
+                    
                 </j:case>
                 <j:case value="ENVS">
-                    <tr align="center">
-                        <th/>
+                    <div class="row">
+                        <div class="cellEmpty"> </div>
                         <j:set var="orderOfEnvs" value="${it.getOrderOfEnvs()}"/>
                         <j:set var="orderOfComps" value="${it.getOrderOfComps()}"/>
                         <j:set var="customColumnsList" value="${it.getCustomDBColumns()}"/>
 
                         <j:forEach items="${orderOfEnvs}" var="envsHeader">
-                            <th style="text-align:center">
-                                <a style="text-decoration:none" title="View environment history" id="${envsHeader}_Header" href="javascript:toggle('${envsHeader}_History');">${envsHeader}</a>
+                            <div class="cell envHeader">
+                                <a class="envHeaderLink" title="View environment history" id="${envsHeader}_Header" href="javascript:toggle('${envsHeader}_History');">${envsHeader}</a>
                                 <div id="${envsHeader}_History" style="display: inline-block; position: fixed; top: 100; bottom: 100; left: 0; right: 0; width: 900px; height: 600px; position:fixed; margin: auto; padding: 10px; background-color: #FEFEFE; border: 1px solid; border-color: #DDDDDD; box-shadow: 1px 2px 1px #AAAAAA; border-radius: 15px; display:none; overflow: auto; overflow-x:hidden;">
                                     <div align="right">
                                         <b onclick="javascript:hideAll()" style="cursor: pointer">[X]</b>
@@ -206,76 +206,63 @@
                                         </table>
                                     </div>
                                 </j:forEach>
-                            </th>
+                            </div>
                         </j:forEach>
-                    </tr>
+                    </div>
 
 
                     <!-- Main dashboard -->
                     <j:forEach items="${orderOfComps}" var="comps">
-                        <tr>
-                            <td align="center"><strong><a href="javascript:toggle('${comps}_History')">${comps}</a></strong></td>
+                        <div class="row">
+                            <div class="cell componentHeader"><a class="compHeaderLink" href="javascript:toggle('${comps}_History')">${comps}</a></div>
                             <j:forEach items="${orderOfEnvs}" var="env">
                                 <j:set var="deployment" value="${it.getCompLastDeployed(env, comps)}"/>
                                 <j:if test="${!deployment.isEmpty()}">
                                     <j:switch on="${deployment.get('buildstatus')}">
                                         <j:case value="SUCCESS">
                                             <j:set var="bgcol" value="#DAF5DA;"/>
-                                            <j:set var="clss" value="notused"/>
+                                            <j:set var="clss" value="jobResult success"/>
                                             <j:set var="extn" value=""/>
                                         </j:case>
                                         <j:case value="FAILURE">
                                             <j:set var="bgcol" value="#FF6666;"/>
-                                            <j:set var="clss" value="notused"/>
+                                            <j:set var="clss" value="jobResult failure"/>
                                             <j:set var="extn" value=""/>
                                         </j:case>
                                         <j:case value="RUNNING">
                                             <j:set var="bgcol" value="#ffffff;"/>
-                                            <j:set var="clss" value="deploying"/>
+                                            <j:set var="clss" value="jobResult deploying"/>
                                             <j:set var="extn" value="console"/>
                                         </j:case>
                                         <j:default>
                                             <j:set var="bgcol" value="#eccf97;"/>
-                                            <j:set var="clss" value="notused"/>
+                                            <j:set var="clss" value="jobResult None"/>
                                             <j:set var="extn" value="console"/>
                                         </j:default>
                                     </j:switch>
 
-                                    <td class="${clss}" style="background-color:${bgcol} padding 1.5% 1.5%;" align="center">
-                                        <a style="text-decoration:none; color:blue; font-size:medium;" title="View" href="javascript:toggle('${comps}_${env}_Popup');">
+                                    <div class="cell ${clss}" align="center" title="${deployment}">
+                                        <a class="packageName" title="View" href="javascript:toggle('${comps}_${env}_Popup');">
                                             <strong>
                                                 <j:if test="${deployment.get('packageName').equals('') || deployment.get('packageName') == null}">${deployment.get('buildNum')}</j:if>
                                                 <j:if test="${!deployment.get('packageName').equals('') &amp;&amp; deployment.get('packageName') != null}">${deployment.get('packageName')}</j:if>
-												<j:switch on="${deployment.get('buildstatus')}">
-													<j:case value="SUCCESS">
-                                                        <span title="SUCCESS" style="color:green;">&#10004;</span>
-													</j:case>
-													<j:case value="FAILURE">
-                                                        <span title="FAILURE" style="color:darkred;">&#x2716;</span>
-													</j:case>
-													<j:case value="RUNNING">
-                                                        <span title="RUNNING" style="color:blue;">&#9658;</span>
-													</j:case>
-													<j:default>
-                                                        <span title="UNKNOWN" style="color:orange;">&#63;</span>
-													</j:default>
-												</j:switch>
+									
 											</strong>
                                         </a>
                                         <div align="right">
                                             <code>
-                                                <a style="font-size:small; text-decoration:none;" title="View Deployment" href="${deployment.get('jobUrl')}${extn}">[${it.getNiceTimeStamp(deployment.get('created_at'))}]</a>
+                                                <a class="buildDate" title="View Deployment" href="${deployment.get('jobUrl')}${extn}">[${it.getNiceTimeStamp(deployment.get('created_at'))}]</a>
                                             </code>
                                         </div>
-                                    </td>
+                                    </div>
                                 </j:if>
                                 <j:if test="${deployment.isEmpty()}">
-                                    <td>
-                                        <div align="center" style="font-size:15px;"><strong>---</strong></div>
-                                    </td>
+                                    <div class="cell jobResult none">
+                                        <div align="center" style="font-size:15px;"><strong>N/A</strong></div>
+                                    </div>
                                 </j:if>
                             </j:forEach>
-                        </tr>
+                        </div>
                     </j:forEach>
 
                     <script language="javascript">
@@ -312,7 +299,6 @@
                     </script>
                 </j:case>
             </j:switch>
-        </tbody>
-    </table>
+
 </div>
 </j:jelly>

--- a/src/main/webapp/css/blink.css
+++ b/src/main/webapp/css/blink.css
@@ -1,18 +1,26 @@
 @-webkit-keyframes deploying {
-  from { background-color: #3498db; }
-  to { background-color: inherit; }
+  from { background-color: #2F89C5; 
+          color: white; }
+  to { background-color: #9ACCED;
+          color: white;  }
 }
 @-moz-keyframes deploying {
-  from { background-color: #3498db; }
-  to { background-color: inherit; }
+  from { background-color: #2F89C5; 
+          color: white; }
+  to { background-color: #9ACCED;
+          color: white;  }
 }
 @-o-keyframes deploying {
-  from { background-color: #3498db; }
-  to { background-color: inherit; }
+  from { background-color: #2F89C5; 
+          color: white; }
+  to { background-color: #9ACCED;
+          color: white;  }
 }
 @keyframes deploying {
-  from { background-color: #3498db; }
-  to { background-color: inherit; }
+  from { background-color: #2F89C5; 
+          color: white; }
+  to { background-color: #9ACCED;
+          color: white;  }
 }
 .deploying {
   -webkit-animation: deploying 2s infinite; /* Safari 4+ */

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -1,0 +1,82 @@
+.tableDiv{
+  display: table;
+  border-collapse: separate;
+  border-spacing: 10px;
+}
+.row {
+  display: table-row;
+}
+.cellEmpty{
+    display: table-cell;
+    width: 16em;
+}
+.cell {
+    display: table-cell;
+    width: 20%;
+    padding: 1em 2em;
+    background: #f6c75d;
+    border: 4px solid #de9542;
+    border-radius: 25px; /* Standard */
+    -o-border-radius: 25px; /* Opera 10.x */
+    -moz-border-radius: 25px; /* Mozilla/Firefox */
+    -icab-border-radius: 25px; /* iCab */
+    -khtml-border-radius: 25px; /* KHTML/Konqueror */
+    -webkit-border-radius: 25px; /* Webkit/Safari/Chrome/etcetera */
+    vertical-align: middle;
+}
+
+.cell.jobResult.success {
+	background-color: #009900;
+	border-color: #004C00;
+	color:white;
+}
+.cell.jobResult.failure {
+	background-color: #E60000;
+	border-color: #800000;
+	color:white;
+}
+.cell.jobResult.none {
+	background-color: #B2B2B2;
+	border-color: #666666;
+	color:black;
+}
+.cell.jobResult a.packageName {
+	color: inherit;
+	text-decoration:none;
+	font-size:medium;
+}
+a.buildDate {
+	font-size:small; 
+	text-decoration:none;
+	color: antiquewhite;
+}
+.cell.deploying {
+	border-color: #246A99;
+}
+
+div.cell.envHeader, div.cell.componentHeader {
+	text-align:center;
+	background-color: #389B9B;
+	border-color: #256767;
+}
+div.cell.envHeader a.envHeaderLink {
+	text-decoration:none;
+	font-size: larger;
+	text-transform: uppercase;
+	color: white;
+	font-weight: bold;
+}
+div.cell.envHeader a:hover, div.cell.componentHeader a:hover {
+	color: #B2B2B2;
+}
+
+div.cell.componentHeader a.compHeaderLink{
+	font-size: larger;
+	text-decoration: none;
+	color: white;
+	font-weight: bold;
+}
+td, tr {
+	margin: 0.25em;
+}
+


### PR DESCRIPTION
I've updated the main.jelly page to use css classes instead of hard coded styles for the main table display of components and environments. It also uses css grid layout instead of tables.

Looks like this now:
![cssgrid](https://cloud.githubusercontent.com/assets/13536053/9324602/e9a24880-4583-11e5-9599-58192f6de944.PNG)
