### PR TITLE
Enhancements to define groovy job dsl closure for environment dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ local.properties
 .idea/
 *.iml
 *.iws
+*.ipr
 
 # External tool builders
 .externalToolBuilders/

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Once you have run at least one job with a populated Details for Environment dash
 
 ## Job DSL ##
 
-'''groovy
+```groovy
 environmentDashboard {
     environmentName(String environmentName)
     componentName(String componentName)
@@ -63,7 +63,7 @@ environmentDashboard {
     addColumns(boolean addColumns)
     columns(String columnName, String contents)
 }
-'''
+```
 
 The groovy DSL can be used in conjunction with Job DSL plugin to provide a definition of environment dashboard section within a job.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The groovy DSL can be used in conjunction with Job DSL plugin to provide a defin
 
 Examples
 
-'''groovy
+```groovy
 job('example-1') {
     wrappers {
         environmentDashboard {
@@ -93,4 +93,4 @@ job('example-2') {
           }
         }
 }
-'''
+```

--- a/README.md
+++ b/README.md
@@ -49,3 +49,48 @@ After installing the plugin, you'll get a new option in the Build Environment se
 You can also specify how long you want to retain the dashboard data, the default is set to 30 days. Any data older than 30 days from the current time is automatically deleted.
 
 Once you have run at least one job with a populated Details for Environment dashboard section, you now have enough data to generate a dashboard.  On the Jenkins home page, click the + to create a new view and create a view.  If you leave all settings blank, you will see the deployments of all components into all environments. You can also limit the deployment history shown when you click on the environment name on the dashboard. The default is last 10 deploys.
+
+
+## Job DSL ##
+
+'''groovy
+environmentDashboard {
+    environmentName(String environmentName)
+    componentName(String componentName)
+    buildNumber(String buildNumber)
+    buildJob(String buildJob)
+    packageName(String packageName)
+    addColumns(boolean addColumns)
+    columns(String columnName, String contents)
+}
+'''
+
+The groovy DSL can be used in conjunction with Job DSL plugin to provide a definition of environment dashboard section within a job.
+
+Examples
+
+'''groovy
+job('example-1') {
+    wrappers {
+        environmentDashboard {
+            environmentName('Environment-1')
+            componentName('WebApp-1')
+            buildNumber('Version-1')
+          }
+        }
+}
+
+// Add custom columns
+job('example-2') {
+    wrappers {
+        environmentDashboard {
+            environmentName('Environment-1')
+            componentName('WebApp-1')
+            buildNumber('Version-1')
+            addColumns(true)
+            column('Col1', 'Column 1 contents')
+            column('Col2', 'Column 2 contents')
+          }
+        }
+}
+'''

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,12 @@
           <artifactId>jquery</artifactId>
           <version>1.7.2-1</version>
       </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>job-dsl</artifactId>
+          <version>1.39</version>
+          <optional>true</optional>
+      </dependency>
   </dependencies>
 
   <licenses>

--- a/src/main/java/org/jenkinsci/plugins/environmentdashboard/EnvDashboardDslContext.java
+++ b/src/main/java/org/jenkinsci/plugins/environmentdashboard/EnvDashboardDslContext.java
@@ -1,14 +1,10 @@
 package org.jenkinsci.plugins.environmentdashboard;
 
 import javaposse.jobdsl.dsl.Context;
-import org.apache.commons.lang.StringUtils;
-
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 
-/*
-Environment Dashboard DSL Context
+/**
+ * Environment Dashboard DSL Context
  */
 public class EnvDashboardDslContext implements Context {
     String nameOfEnv = "";

--- a/src/main/java/org/jenkinsci/plugins/environmentdashboard/EnvDashboardDslContext.java
+++ b/src/main/java/org/jenkinsci/plugins/environmentdashboard/EnvDashboardDslContext.java
@@ -1,0 +1,50 @@
+package org.jenkinsci.plugins.environmentdashboard;
+
+import javaposse.jobdsl.dsl.Context;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+Environment Dashboard DSL Context
+ */
+public class EnvDashboardDslContext implements Context {
+    String nameOfEnv = "";
+    String componentName = "";
+    String buildNumber = "";
+    String buildJob = "";
+    String packageName = "";
+    boolean addColumns = false;
+    ArrayList<ListItem> data = new ArrayList<ListItem>();
+
+    public void environmentName(String value) {
+        nameOfEnv = value;
+    }
+
+    public void componentName(String value) {
+        componentName = value;
+    }
+
+    public void buildNumber(String value) {
+        buildNumber = value;
+    }
+
+    public void buildJob(String value) {
+        buildJob = value;
+    }
+
+    public void packageName(String value) {
+        packageName = value;
+    }
+
+    public void addColumns(boolean value) {
+        addColumns = value;
+    }
+
+    public void column(String columnName, String contents) {
+        ListItem col = new ListItem(columnName, contents);
+        data.add(col);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/environmentdashboard/EnvDashboardDslContextExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/environmentdashboard/EnvDashboardDslContextExtension.java
@@ -35,7 +35,7 @@ public class EnvDashboardDslContextExtension extends ContextExtensionPoint {
     }
 
     /**
-     * DSL extension method to handle non-existent closure environment dashboard wrapper context.
+     * DSL extension method to handle non-existent closure for environment dashboard wrapper context.
      * @return
      *
      * Example:

--- a/src/main/java/org/jenkinsci/plugins/environmentdashboard/EnvDashboardDslContextExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/environmentdashboard/EnvDashboardDslContextExtension.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.environmentdashboard;
+
+import hudson.Extension;
+import javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext;
+import javaposse.jobdsl.plugin.ContextExtensionPoint;
+import javaposse.jobdsl.plugin.DslExtensionMethod;
+
+@Extension(optional = true)
+public class EnvDashboardDslContextExtension extends ContextExtensionPoint {
+
+    /*
+    DSL extension method to handle the nested/empty environment dashboard wrapper context.
+
+    Example 1: Nested context
+    environmentDashboard {
+      nameOfEnv('EnvA')
+      componentName('ComponentB')
+      buildNumber('1')
+    }
+
+    Example 2: Empty context
+    environmentDashboard {}
+     */
+    @DslExtensionMethod(context = WrapperContext.class)
+    public Object environmentDashboard(Runnable closure) {
+        EnvDashboardDslContext context = new EnvDashboardDslContext();
+        executeInContext(closure, context);
+        return new DashboardBuilder(context.nameOfEnv, context.componentName, context.buildNumber,
+                context.buildJob, context.packageName, context.addColumns, context.data);
+    }
+
+    /*
+    DSL extension method to handle non-existent closure environment dashboard wrapper context.
+
+    Example:
+    environmentDashboard()
+     */
+    @DslExtensionMethod(context = WrapperContext.class)
+    public Object environmentDashboard() {
+        EnvDashboardDslContext context = new EnvDashboardDslContext();
+        return new DashboardBuilder(context.nameOfEnv, context.componentName, context.buildNumber,
+                context.buildJob, context.packageName, context.addColumns, context.data);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/environmentdashboard/EnvDashboardDslContextExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/environmentdashboard/EnvDashboardDslContextExtension.java
@@ -5,21 +5,26 @@ import javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext;
 import javaposse.jobdsl.plugin.ContextExtensionPoint;
 import javaposse.jobdsl.plugin.DslExtensionMethod;
 
+/**
+ * Environment Dashboard DSL context extension class
+ */
 @Extension(optional = true)
 public class EnvDashboardDslContextExtension extends ContextExtensionPoint {
 
-    /*
-    DSL extension method to handle the nested/empty environment dashboard wrapper context.
-
-    Example 1: Nested context
-    environmentDashboard {
-      nameOfEnv('EnvA')
-      componentName('ComponentB')
-      buildNumber('1')
-    }
-
-    Example 2: Empty context
-    environmentDashboard {}
+    /**
+     * DSL extension method to handle the nested/empty environment dashboard wrapper context.
+     * @param closure
+     * @return
+     *
+     * Example 1: Nested context
+     * environmentDashboard {
+     *     environmentName('Environment-1')
+     *     componentName('WebApp-1')
+     *     buildNumber('Version-1')
+     * }
+     *
+     * Example 2: Empty context
+     * environmentDashboard {}
      */
     @DslExtensionMethod(context = WrapperContext.class)
     public Object environmentDashboard(Runnable closure) {
@@ -29,11 +34,12 @@ public class EnvDashboardDslContextExtension extends ContextExtensionPoint {
                 context.buildJob, context.packageName, context.addColumns, context.data);
     }
 
-    /*
-    DSL extension method to handle non-existent closure environment dashboard wrapper context.
-
-    Example:
-    environmentDashboard()
+    /**
+     * DSL extension method to handle non-existent closure environment dashboard wrapper context.
+     * @return
+     *
+     * Example:
+     * environmentDashboard()
      */
     @DslExtensionMethod(context = WrapperContext.class)
     public Object environmentDashboard() {


### PR DESCRIPTION
Hi All

Changes in this pull request are related to defining a groovy-based dsl closure for environment dashboard plugin. This would allow us to use this in conjunction with Job DSL plugin. All the ADOP cartridges can then easily use this closure instead of having to resort to configure blocks to generate the xml content.

Best Regards,
Momin Khan
