### PR TITLE
Update blink.css - use more specific CSS selectors

### DIFF
--- a/src/main/webapp/css/blink.css
+++ b/src/main/webapp/css/blink.css
@@ -21,6 +21,6 @@
   animation:         deploying 2s infinite; /* IE 10+ */
 }
 
-#side-panel { display: none; }
+#page-body #side-panel { display: none; }
 
-#main-panel { width: 100%; margin-left: 0px; }
+#page-body #main-panel { width: 100%; margin-left: 0px; }


### PR DESCRIPTION
When plugin is installed on Jenkins 2.46, styles from layout-common.css override those in blink.css.
As a result empty side-panel is visible and main-panel does not fit page width.

Change prevent these styles from being overridden.
It should also be compatible with Jenkins 1.X (#page-body id is present on parent div).