### PR TITLE
Fix popup styles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.12</version>
+    <version>3.50</version>
   </parent>
   
   <properties>

--- a/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/main.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/main.jelly
@@ -153,7 +153,7 @@
                                 <!-- Component History -->
                                 <j:forEach items="${orderOfComps}" var="comp">
                                     <j:set var="compLastDeployed" value="${it.getCompLastDeployed(envsHeader, comp)}"/>
-                                    <div id="${comp}_History" style="display: inline-block; position: fixed; top: 100; bottom: 100; left: 0; right: 0; width: 900px; height: 600px; position:fixed; margin: auto; padding: 10px; background-color: #FEFEFE; border: 1px solid; border-color: #DDDDDD; box-shadow: 1px 2px 1px #AAAAAA; border-radius: 15px; display:none; overflow: auto; overflow-x:hidden;">
+                                    <div id="${comp}_History" class="env-dashboard-popup">
                                         <div align="right">
                                             <b onclick="javascript:hideAll()" style="cursor: pointer">[X]</b>
                                         </div>

--- a/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/main.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/environmentdashboard/EnvDashboardView/main.jelly
@@ -28,7 +28,7 @@
                         <j:forEach items="${orderOfEnvs}" var="envsHeader">
                             <th style="text-align:center">
                                 <a style="text-decoration:none" title="View environment history" id="${envsHeader}_Header" href="javascript:toggle('${envsHeader}_History');">${envsHeader}</a>
-                                <div id="${envsHeader}_History" style="display: inline-block; position: fixed; top: 100; bottom: 100; left: 0; right: 0; width: 900px; height: 600px; position:fixed; margin: auto; padding: 10px; background-color: #FEFEFE; border: 1px solid; border-color: #DDDDDD; box-shadow: 1px 2px 1px #AAAAAA; border-radius: 15px; display:none; overflow: auto; overflow-x:hidden;">
+                                <div id="${envsHeader}_History" class="env-dashboard-popup">
                                     <div align="right">
                                         <b onclick="javascript:hideAll()" style="cursor: pointer">[X]</b>
                                     </div>
@@ -87,12 +87,12 @@
                                 <!-- Popup per Env per Component  -->
                                 <j:forEach items="${orderOfComps}" var="comp">
                                     <j:set var="compLastDeployed" value="${it.getCompLastDeployed(envsHeader, comp)}"/>
-                                    <div id="${comp}_${envsHeader}_Popup" style="display: inline-block; position: fixed; top: 100; bottom: 100; left: 0; right: 0; width: 900px; height: 600px; position:fixed; margin: auto; padding: 10px; background-color: #FEFEFE; border: 1px solid; border-color: #DDDDDD; box-shadow: 1px 2px 1px #AAAAAA; border-radius: 15px; display:none; overflow: auto; overflow-x:hidden;">
+                                    <div id="${comp}_${envsHeader}_Popup" class="env-dashboard-popup">
                                         <div align="right">
                                             <b onclick="javascript:hideAll()" style="cursor: pointer">[X]</b>
                                         </div>
                                         <h3>${comp + "   |   " + envsHeader}</h3>
-                                         <table style="width=100%" class="table table-bordered table-striped table-condensed">
+                                         <table class="table table-bordered table-striped table-condensed">
                                             <tbody>
                                                 <th style="width: 8%;text-align:center">Build</th>
                                                 <j:if test="${compLastDeployed.get('packageName') != null &amp;&amp; !compLastDeployed.get('packageName').equals('')}">

--- a/src/main/webapp/css/blink.css
+++ b/src/main/webapp/css/blink.css
@@ -24,3 +24,23 @@
 #side-panel { display: none; }
 
 #main-panel { margin-left: 0px; }
+
+.env-dashboard-popup {
+  display: none;
+  position: fixed;
+  top: 100px;
+  bottom: 100px;
+  left: 0;
+  right: 0;
+  min-width: 900px;
+  max-width: 90%;
+  min-height: 600px;
+  max-height: 90%;
+  margin: auto;
+  padding: 10px;
+  background-color: #FEFEFE;
+  border: 1px solid #DDDDDD;
+  box-shadow: 1px 2px 1px #AAAAAA;
+  border-radius: 15px;
+  overflow: auto;
+}


### PR DESCRIPTION
1. Replace inline styles with class
2. Make the popup size more flexible so it can adapt to window size
3. Allow overflow scrolls (if table is larger than current size of popup)

This pull request should fix #145 & #153.

I have tested it on Jenkins ver. 2.190.1