### PR TITLE
Revert to 1.1.8-snapshot, we almost skipped 1.1.8!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   
   <groupId>io.jenkins.plugins</groupId>
   <artifactId>environment-dashboard</artifactId>
-  <version>1.1.9-SNAPSHOT</version>
+  <version>1.1.8-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Environment Dashboard Plugin</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Environment+dashboard+plugin</url>


### PR DESCRIPTION
As per title, this bumps the version in `pom.xml` back to where it should be, so we can prepare the release of `1.1.8`.